### PR TITLE
Replaced sync-depth (deprecated) with clone-depth

### DIFF
--- a/README
+++ b/README
@@ -13,5 +13,5 @@ location = /var/lib/layman/gentoo-italia
 sync-type = git
 sync-uri = https://github.com/viralex/gentoo-italia
 auto-sync = yes
-sync-depth = 1
+clone-depth = 1
 ---------------------------------------------------


### PR DESCRIPTION

Replaced sync-depth (deprecated) with clone-depth
```
/usr/lib/python3.4/site-packages/portage/repository/config.py:176: UserWarning: repos.conf: sync-depth is deprecated, use clone-depth instead
  warnings.warn(_("repos.conf: sync-depth is deprecated,"
```
